### PR TITLE
Add Proxmox template helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# templates-proxmox
+# Proxmox Template Scripts
+
+This repository contains simple bash utilities for working with Proxmox VM templates.
+
+* `scripts/create_templates.sh` – download Ubuntu cloud images and create template VMs directly on the Proxmox host.
+* `scripts/download_templates.sh` – fetch existing template disks from a Proxmox server to your local machine.
+* `scripts/upload_templates.sh` – upload local template disks to a Proxmox server and convert them to templates.
+
+Each script contains configuration variables at the top for the Proxmox host, user and storage. Edit them to match your environment before running.

--- a/scripts/create_templates.sh
+++ b/scripts/create_templates.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# This script downloads Ubuntu cloud images and creates Proxmox templates
+# for versions 18.04, 20.04, 22.04 and 24.04. It must be executed on the
+# Proxmox server.
+
+set -euo pipefail
+
+# --- Configuration ---
+STORAGE="local-lvm"        # Storage where disks will be imported
+BRIDGE="vmbr0"             # Network bridge to attach VMs
+RAM=2048                   # Memory for each template VM
+CI_USER="root"            # cloud-init username
+CI_PASS="root"            # cloud-init password
+
+# Map of VMID to image details
+declare -A IMAGES=(
+  [1000]="18.04"
+  [1001]="20.04"
+  [1002]="22.04"
+  [1003]="24.04"
+)
+
+BASE_URL="http://cloud-images.ubuntu.com/releases"
+
+# --- Main loop ---
+for VMID in "${!IMAGES[@]}"; do
+    VERSION="${IMAGES[$VMID]}"
+    IMAGE="ubuntu-${VERSION}-server-cloudimg-amd64.img"
+    URL="$BASE_URL/${VERSION%%.*}/release/$IMAGE"
+    VMNAME="u${VERSION%%.*}s-tpl"
+
+    echo "=== Processing Ubuntu $VERSION (VMID $VMID) ==="
+    if [[ ! -f /tmp/$IMAGE ]]; then
+        echo "Downloading $IMAGE ..."
+        wget -q -O "/tmp/$IMAGE" "$URL"
+    fi
+
+    echo "Creating VM ..."
+    qm create "$VMID" \
+        --memory "$RAM" \
+        --net0 virtio,bridge="$BRIDGE" \
+        --name "$VMNAME" \
+        --scsihw virtio-scsi-pci
+
+    virt-customize -a "/tmp/$IMAGE" --install qemu-guest-agent >/dev/null
+
+    qm set "$VMID" --scsi0 "$STORAGE:0,import-from=/tmp/$IMAGE"
+    qm set "$VMID" --ide2 "$STORAGE:cloudinit"
+    qm set "$VMID" --boot order=scsi0
+    qm set "$VMID" --serial0 socket --vga serial0
+    qm set "$VMID" --ipconfig0 ip=dhcp
+    qm set "$VMID" --agent enabled=1
+    qm set "$VMID" -ciuser "$CI_USER"
+    qm set "$VMID" -cipassword "$CI_PASS"
+    qm template "$VMID"
+    echo "Template $VMID ($VMNAME) ready."
+    echo "------------------------------------"
+
+done
+
+echo "All templates created."

--- a/scripts/download_templates.sh
+++ b/scripts/download_templates.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Download template raw disks and cloud-init images from a Proxmox server
+# to the local machine. Each template will be placed in a directory named
+# after its VMID.
+
+set -euo pipefail
+
+# --- Config ---
+PROXMOX_HOST="192.168.1.110"
+PROXMOX_USER="root"
+BASE_PATH="$(pwd)"
+
+# Map VMIDs to human readable names (optional)
+declare -A VM_NAMES=(
+  [1000]="u18s-tpl"
+  [1001]="u20s-tpl"
+  [1002]="u22s-tpl"
+  [1003]="u24s-tpl"
+)
+
+# --- Prompt user ---
+echo "Available templates on Proxmox:"
+for VMID in "${!VM_NAMES[@]}"; do
+    echo "  [$VMID] - ${VM_NAMES[$VMID]}"
+    done
+
+read -p "Enter VMIDs to download (separated by spaces): " -a SELECTED_VMS
+
+# --- Download loop ---
+for VMID in "${SELECTED_VMS[@]}"; do
+    DIR="$BASE_PATH/$VMID"
+    mkdir -p "$DIR"
+
+    echo "Fetching files for VMID $VMID ..."
+    DISK_FILE=$(ssh "$PROXMOX_USER@$PROXMOX_HOST" "ls /var/lib/vz/images/$VMID | grep -o 'base-$VMID-disk-0\\.raw' || true")
+    CLOUDINIT_FILE="vm-${VMID}-cloudinit.qcow2"
+
+    if [[ -z "$DISK_FILE" ]]; then
+        echo "  Disk file for $VMID not found on server, skipping.";
+        continue
+    fi
+
+    scp "$PROXMOX_USER@$PROXMOX_HOST:/var/lib/vz/images/$VMID/$DISK_FILE" "$DIR/"
+    if ssh "$PROXMOX_USER@$PROXMOX_HOST" "test -f /var/lib/vz/images/$VMID/$CLOUDINIT_FILE"; then
+        scp "$PROXMOX_USER@$PROXMOX_HOST:/var/lib/vz/images/$VMID/$CLOUDINIT_FILE" "$DIR/"
+    fi
+
+    echo "  Downloaded $VMID to $DIR"
+done
+
+echo "Done." 

--- a/scripts/upload_templates.sh
+++ b/scripts/upload_templates.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Upload local template disks and cloud-init images to a Proxmox server and
+# create the VMs as templates. Files for each VMID should be stored in a
+# directory named after the VMID.
+
+set -euo pipefail
+
+# --- Config ---
+PROXMOX_HOST="192.168.1.110"
+PROXMOX_USER="root"
+STORAGE="local"
+BRIDGE="vmbr0"
+RAM=2048
+MAKE_TEMPLATE=true
+BASE_PATH="$(pwd)"
+
+# Map VMIDs to names
+declare -A VM_NAMES=(
+  [1000]="u18s-tpl"
+  [1001]="u20s-tpl"
+  [1002]="u22s-tpl"
+  [1003]="u24s-tpl"
+)
+
+# --- List templates available locally ---
+echo "Available local templates:"
+for DIR in "$BASE_PATH"/100*/; do
+    VMID=$(basename "$DIR")
+    echo "  [$VMID] - ${VM_NAMES[$VMID]:-unknown}"
+done
+
+read -p "Enter VMIDs to upload (separated by spaces): " -a SELECTED_VMS
+
+# --- Main loop ---
+for VMID in "${SELECTED_VMS[@]}"; do
+    DIR="$BASE_PATH/$VMID"
+    VMNAME="${VM_NAMES[$VMID]}"
+
+    DISK_FILE="base-${VMID}-disk-0.raw"
+    CLOUDINIT_FILE="vm-${VMID}-cloudinit.qcow2"
+
+    if [[ ! -f "$DIR/$DISK_FILE" || ! -f "$DIR/$CLOUDINIT_FILE" ]]; then
+        echo "Skipping $VMID: files missing";
+        continue
+    fi
+
+    echo "Uploading files for $VMID ..."
+    ssh "$PROXMOX_USER@$PROXMOX_HOST" "mkdir -p /var/lib/vz/images/$VMID"
+    scp "$DIR/$DISK_FILE" "$PROXMOX_USER@$PROXMOX_HOST:/var/lib/vz/images/$VMID/"
+
+    if ! ssh "$PROXMOX_USER@$PROXMOX_HOST" "test -f /var/lib/vz/images/$VMID/$CLOUDINIT_FILE"; then
+        scp "$DIR/$CLOUDINIT_FILE" "$PROXMOX_USER@$PROXMOX_HOST:/var/lib/vz/images/$VMID/"
+    fi
+
+    ssh "$PROXMOX_USER@$PROXMOX_HOST" \
+        "qm create $VMID --name $VMNAME --memory $RAM --net0 virtio,bridge=$BRIDGE"
+    ssh "$PROXMOX_USER@$PROXMOX_HOST" \
+        "qm importdisk $VMID /var/lib/vz/images/$VMID/$DISK_FILE $STORAGE"
+
+    DISK_NAME=$(ssh "$PROXMOX_USER@$PROXMOX_HOST" "ls /var/lib/vz/images/$VMID | grep -o 'vm-${VMID}-disk-[0-9]*\\.raw' | head -n1")
+    if [[ -z "$DISK_NAME" ]]; then
+        echo "  Failed to detect imported disk for VMID $VMID";
+        continue
+    fi
+
+    ssh "$PROXMOX_USER@$PROXMOX_HOST" \
+        "qm set $VMID --scsihw virtio-scsi-pci --scsi0 $STORAGE:$VMID/$DISK_NAME"
+    ssh "$PROXMOX_USER@$PROXMOX_HOST" "qm set $VMID --ide2 $STORAGE:cloudinit"
+    ssh "$PROXMOX_USER@$PROXMOX_HOST" "qm set $VMID --boot order=scsi0"
+
+    if [ "$MAKE_TEMPLATE" = true ]; then
+        ssh "$PROXMOX_USER@$PROXMOX_HOST" "qm template $VMID"
+    fi
+
+    echo "VMID $VMID uploaded and configured"
+    echo "-------------------------------------"
+done
+
+echo "Selected templates uploaded."


### PR DESCRIPTION
## Summary
- create helper script to make Ubuntu template VMs directly on Proxmox
- add script to download template disks from a Proxmox host
- add script to upload local template disks and turn them into templates
- document the scripts in the README

## Testing
- `bash -n scripts/create_templates.sh`
- `bash -n scripts/download_templates.sh`
- `bash -n scripts/upload_templates.sh`

------
https://chatgpt.com/codex/tasks/task_e_687bae59d64c8322bc36d0ac9f920ed8